### PR TITLE
[feat] ImageView 컴포넌트 추가

### DIFF
--- a/src/components/common/ImageView.jsx
+++ b/src/components/common/ImageView.jsx
@@ -1,0 +1,61 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import styled from "styled-components";
+import SVG from "./SVG";
+import Enum from "../../constants/Enum";
+
+const EmptyImg = ({isNull}) => {
+  return isNull ? null : (<EmptyBox><SVG type={Enum.PICTURE} /></EmptyBox>);
+}
+
+
+const ImageView = memo(({isNull, imageUrl}) => {
+  return (
+    <ContainerImg>
+      {imageUrl ?
+        <ImgArea src={imageUrl} alt={"ImgArea"} />
+      :
+        <EmptyImg isNull={isNull}/>
+      }
+    </ContainerImg>
+  );
+});
+
+ImageView.propTypes = {
+  isNull: PropTypes.bool,
+  imageUrl: PropTypes.string
+};
+
+const ContainerImg = styled.div`
+  position: relative;
+  width: ${(props) => props.width || "100%"};
+  height: 0;
+  padding-bottom: ${(props) => props.height || "calc(100% / 1.7)"};
+`;
+
+
+/*374px * 212px : 1.7*/
+const EmptyBox = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #FAFAFA;
+  border: 1px solid #E5E8EC;
+  box-sizing: border-box;
+  border-radius: 5px;
+  text-align: center;
+`;
+
+const ImgArea = styled.img`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-repeat: no-repeat /*background-image가 컨테이너를 가득 채우지 못할 경우에도 반복하지 않는다.*/
+  background-size: cover; /*사이즈가 container에 맞지 않아도 꽉 차도록 채운다.*/
+  background-position: center; /*background-image가 컨테이너에 가운데로 오도록 한다. */
+`;
+
+export default ImageView;


### PR DESCRIPTION
# ImageView 컴포넌트
공통 컴포넌트로 이미지 파일 보여주는 뷰 박스 생성했어요!
1. 화면 비율에 따라 반응형으로 보여주고 만약 원하는 넓이/높이가 있을 경우 props로 수정 가능해요!
2. 이미지 파일이 없을 경우 디폴트로 아이콘 표시됩니다!

해당 컴포넌트에 대한 props 설명 및 예시 소스는 노션에도 남겨둘게요!

```javascript
{/*이미지 파일이 없을 경우*/}
<ImageView imageUrl={null}/>
{/*이미지 파일이 있고 직접 크기 조절할 경우*/}
<ImageView imageUrl={"/src/img/sos.jpg"}/>
```

- 반응형 UI 캡쳐화면 (넓이가 414px, 280px일 경우)
![width_414px](https://user-images.githubusercontent.com/18224086/117639123-8c427400-b1be-11eb-9315-1216c971b8af.png)
![width_280px](https://user-images.githubusercontent.com/18224086/117639212-a3816180-b1be-11eb-983e-00790f91ee85.png)