### PR TITLE
Feature/comm new infinte

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^17.0.2",
     "react-cookies": "^0.1.1",
     "react-dom": "^17.0.2",
+    "react-infinite-scroll-component": "^6.1.0",
     "react-kakao-login": "^2.1.0",
     "react-redux": "^7.2.3",
     "react-responsive-carousel": "^3.2.18",

--- a/src/components/common/InfinScorll.jsx
+++ b/src/components/common/InfinScorll.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState, useCallback } from "react";
+import InfiniteScroll from "react-infinite-scroll-component";
+
+const InfinScorll = ({ children, datas, getMoreDatas, isStop, ...other }) => {
+  const [jsonData, setJsonData] = useState([]);
+  const [hasMore, setHasMore] = useState(true);
+
+  useEffect(() => {
+    const current_scroll = document.documentElement.scrollTop;
+
+    if (current_scroll > 0) {
+      //최상단 스크롤로 이동
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (jsonData.length !== datas.length) {
+      setJsonData(datas);
+      setHasMore(true);
+    } else if (isStop && hasMore) {
+      setHasMore(false);
+    }
+  }, [datas, isStop]);
+
+  return (
+    <div style={{ overflow: "visible", height: "auto" }}>
+      <InfiniteScroll
+        scrollThreshold="400px"
+        dataLength={jsonData.length}
+        next={getMoreDatas}
+        hasMore={hasMore}
+        style={{ overflow: "none" }}
+        loader={
+          <h3 style={{ paddingTop: "15px", textAlign: "center" }}>
+            loading...
+          </h3>
+        }
+        endMessage={
+          <p style={{ textAlign: "center" }}>
+            <b>FIN</b>
+          </p>
+        }
+        {...other}
+      >
+        {children}
+      </InfiniteScroll>
+    </div>
+  );
+};
+
+export default InfinScorll;


### PR DESCRIPTION
# 무한스크롤 공통 컴포넌트 생성

react-infinite-scroll 사용 중 로딩/종료 표시 화면을 통일할 필요가 있을 것 같아서 커스텀 정의

컴포넌트에 대한 예시 사용법 및 상세 설명은 [노션](https://www.notion.so/depromeet/e48fa440f39444f487f71a5504c19072)에도 정의 해놓았습니다~

```javascript
import InfinScroll from "../../components/common/InfinScorll";

const Example = () => {
	const [datas, setDatas] = useState([]);
        const [isStop, setStop] = useState(false);

	const getMoreDatas = useCallback(() => {
            setTimeout(() => {
                if (datas.length < 30) setDatas(Array.from({ length: 20 }));
                else setStop(true);
            }, 1500);
        }, [datas]);

	const handleScroll = useCallback(()  => {
		console.log("호로로로롤");
	},[]);
	
	return(
		<InfinScroll
                      datas={datas}
                      isStop={isStop}
                      getMoreDatas={getMoreDatas}
                      {...동적 추가 가능}
                      onScroll={handleScroll}>
                          {datas.map((item, idx) => {
                                  return (<div key{idx}><h1>Hello Test World</h1></div>);
                          })}
             </InfinScroll>
     );
};
```

datas, isStop, getMoreDatas 세 개의 props는 필수에요~