### PR TITLE
Error 컴포넌트 query로 에러 코드 전달 가능 & css 변경

### DIFF
--- a/src/view/Error.jsx
+++ b/src/view/Error.jsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useMemo } from "react";
+import { withRouter } from "react-router-dom";
 import styled from "styled-components";
+import qs from "query-string";
 
 import { BtnField } from "../components/common";
 import { Section } from "../styles";
@@ -9,16 +11,28 @@ import { md } from "../constants/Enum";
 import msg from "../constants/msg";
 import errorImg from "../resources/images/error.png";
 
-// code: number;
-const Error = ({ code = 404 }) => {
-  const { goBack, goPage } = usePage();
+const { errorPage } = msg;
 
-  // 추후 code에 따라 다른 내용 렌더링 필요
+/*
+ * search: query string; ex) ?errorCode=500
+ * code: number;
+ */
+const Error = ({ location: { search }, code = 404 }) => {
+  const { goBack, goPage } = usePage();
+  const errorCode = useMemo(() => {
+    if (search.length < 1) return code;
+
+    const queryCode = qs.parse(search).errorCode;
+    if (!errorPage.hasOwnProperty(queryCode)) return code;
+
+    return queryCode;
+  }, [search]);
+
   return (
     <ErrorSection>
       <ErrorImg src={errorImg} alt="error" />
       <Title>앗, 여긴 어디? 나는 누구죠?</Title>
-      <Message>{msg.errorPage[code]}</Message>
+      <Message>{errorPage[errorCode]}</Message>
       <Buttons>
         <li>
           <BtnField size={md} color="skyBlue" onClick={() => goPage("/")}>
@@ -37,6 +51,7 @@ const Error = ({ code = 404 }) => {
 
 const ErrorSection = styled(Section)`
   margin: auto;
+  width: 100%;
   text-align: center;
 `;
 
@@ -74,4 +89,4 @@ const Buttons = styled.ul`
   }
 `;
 
-export default Error;
+export default withRouter(Error);

--- a/src/view/Error.jsx
+++ b/src/view/Error.jsx
@@ -26,6 +26,7 @@ const Error = ({ location: { search }, code = 404 }) => {
     if (!errorPage.hasOwnProperty(queryCode)) return code;
 
     return queryCode;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 
   return (


### PR DESCRIPTION
## 작업 내용
1. Error 페이지 이동 시 query로 에러 코드 전달 기능 추가
2. 버튼 가로 길이 짧던 현상 수정
3. 관련 PR #45 

### Error 컴포넌트에 query string으로 code 전달하기 (사진에서 주소창 봐주세요)
> 에러가 발생했을 때 Error 컴포넌트를 return 하는 게 아니라, **아예 페이지를 벗어나고 싶을 때 error code를 전달**하고 싶어서 추가했어요

**1. 에러 발생 시 페이지에서 Error 컴포넌트를 리턴할 때 (기존 기능)**

![image](https://user-images.githubusercontent.com/36118545/120107339-aeb32600-c19b-11eb-8886-3df9b348b051.png)
 ```javascript
const PickTest = () => {
  const { status, loggedIn } = useUser();

  if (status === LOADING) return null;
  if (!loggedIn) return <Error code={403} />; // 페이지 내에서 리턴할 때는 code를 props로 줍니다. default는 404

  return (
    <div>
      <Loading loading={loading} />
      <TitleBox title="어떤 테스트를 만드시나요?" noline>
        ...
      </TitleBox>
    </div>
  );
};
```

**2. 존재하지 않는 페이지여서 Error 뷰 컴포넌트가 표시될 때, query string으로 에러 코드 전달 (추가된 기능)**

![image](https://user-images.githubusercontent.com/36118545/120107622-b9ba8600-c19c-11eb-9405-4f2b6853acfb.png)

1. 기능 : 존재하지 않는 페이지로 이동하면서 에러 코드에 맞는 에러 메시지 출력
2. 사용 방법 : `usePage` hook에서 search에 `?errorCode=403` 등으로 에러 코드 전달. default는 404

```javascript
const TestRelease = () => {
  const savedTest = JSON.parse(sessionStorage.getItem("savedTest"));
  const { goPage } = usePage();

  const submitTest = async () => {
    const { status } = await MakingAPI.submitTest(savedTest.testId);
    if (status === ERROR) { // api 요청이 실패하면
      goPage("/error", "?errorCode=500"); // 존재하지 않는 페이지로 이동하면서 에러 코드 500 전달
    }
  };

  useEffect(() => {
    if (savedTest) submitTest();
    return () => sessionStorage.removeItem("savedTest");
  }, []);
...
}
```

@rktguswjd @beckyi 