### PR TITLE
Feature/feed loading etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react-infinite-scroll-component": "^6.1.0",
     "react-kakao-login": "^2.1.0",
     "react-redux": "^7.2.3",
-    "react-responsive-carousel": "^3.2.18",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import { LOADING } from "./utils/asyncUtils";
 
 import "swiper/swiper.min.css";
 import "swiper/components/pagination/pagination.min.css";
+import "swiper/components/navigation/navigation.min.css";
 
 const App = () => {
   const { checkLogIn, status } = useUser();

--- a/src/components/Feed/Card.jsx
+++ b/src/components/Feed/Card.jsx
@@ -4,10 +4,10 @@ import styled from "styled-components";
 import { Title } from "./Carousel";
 import SVG from "../common/SVG";
 import ENUM from "../../constants/Enum";
-import theme from "../../styles/theme";
+// import theme from "../../styles/theme";
 import usePage from "../../hooks/usePage";
 
-const { blue, deepGray } = theme.colors;
+// const { blue, deepGray } = theme.colors;
 const Card = ({
   title,
   coverImg,
@@ -18,13 +18,13 @@ const Card = ({
   testLink,
 }) => {
   const { goPage } = usePage();
-  const [bookMark, setBookMark] = useState(false);
-  const onClickBookMark = useCallback(
-    (e) => {
-      setBookMark(!bookMark);
-    },
-    [bookMark, setBookMark]
-  );
+  // const [bookMark, setBookMark] = useState(false);
+  // const onClickBookMark = useCallback(
+  //   (e) => {
+  //     setBookMark(!bookMark);
+  //   },
+  //   [bookMark, setBookMark]
+  // );
   const onClickTest = useCallback(
     (e) => {
       goPage(`/${testLink}`);
@@ -32,12 +32,9 @@ const Card = ({
     [goPage, testLink]
   );
 
-  const numberFormat = useCallback(
-    (n) => {
-      return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-    },
-    [sharedCnt, participatedCnt]
-  );
+  const numberFormat = useCallback((n) => {
+    return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }, []);
 
   return (
     <CardBox>

--- a/src/components/Feed/Carousel.jsx
+++ b/src/components/Feed/Carousel.jsx
@@ -1,31 +1,33 @@
-import React, { useCallback, useEffect, useState } from "react";
-import "react-responsive-carousel/lib/styles/carousel.min.css";
-import { Carousel } from "react-responsive-carousel";
+import React, { useCallback, useState } from "react";
 import styled from "styled-components";
 import ImageView from "../common/ImageView";
 import { useSelector } from "react-redux";
 import usePage from "../../hooks/usePage";
+import { Swiper, SwiperSlide } from "swiper/react";
+import SwiperCore, { Autoplay, Pagination, Navigation } from "swiper/core";
 
-export default function CarouselComponent() {
+SwiperCore.use([Autoplay, Pagination, Navigation, Swiper]);
+
+const CarouselComponent = React.memo(() => {
   const { goPage } = usePage();
   const { top5Tests } = useSelector((state) => state.feed);
   const initTitle = top5Tests && top5Tests[0].title;
   const [topTest, setTopTest] = useState({ idx: 0, title: initTitle });
 
-  useEffect(() => {});
-
-  // const [topTest, setTopTest] = useState({});
-  const onClickItem = (idx, item) => {
-    onClickTest();
-  };
-
-  const onChange = (idx, item) => {
-    setTopTest({ idx, title: item.props.title });
-  };
+  const onSlideChange = useCallback(
+    (swiper) => {
+      let currentIndex = swiper.realIndex;
+      setTopTest({
+        idx: currentIndex,
+        title: top5Tests && top5Tests[currentIndex].title,
+      });
+    },
+    [setTopTest, top5Tests]
+  );
 
   const onClickTest = useCallback(
     (e) => {
-      goPage(`/${top5Tests && top5Tests[topTest.idx].testLink}`);
+      goPage(`/${top5Tests[topTest.idx].testLink}`);
     },
     [goPage, top5Tests, topTest]
   );
@@ -38,39 +40,57 @@ export default function CarouselComponent() {
       </TitleBox>
 
       <CarouselBox>
-        {top5Tests && (
-          <Carousel
-            showArrows
-            showIndicators
-            infiniteLoop
-            useKeyboardArrows
-            autoPlay
-            stopOnHover
-            swipeable
-            emulateTouch
-            showStatus={false}
-            showThumbs={false}
-            interval={5000}
-            onClickItem={onClickItem}
-            onChange={onChange}
-            selectedItem={0}
-          >
-            {top5Tests.map((test) => (
-              <ImageView
-                key={test.uid}
-                imageUrl={test.coverImg}
-                title={test.title}
-                height="calc(100% / 1.76)"
-                border={false}
-              />
+        <Swiper
+          key="carousel-swiper"
+          slidesPerView={"auto"}
+          centeredSlides={true}
+          navigation={true}
+          onSlideChange={onSlideChange}
+          autoplay={{
+            delay: "5000",
+            disableOnInteraction: false,
+          }}
+          pagination={{
+            clickable: true,
+          }}
+          className="mySwiper"
+        >
+          {top5Tests &&
+            top5Tests.map((test) => (
+              <SwiperSlide onClick={onClickTest}>
+                <ImageView
+                  key={`key_${test.uid}`}
+                  imageUrl={test.coverImg}
+                  title={test.title}
+                  height="calc(100% / 1.76)"
+                  border={false}
+                />
+              </SwiperSlide>
             ))}
-          </Carousel>
-        )}
+        </Swiper>
       </CarouselBox>
     </Ranking>
   );
-}
+});
 
+export default CarouselComponent;
+
+const CarouselBox = styled.div`
+  .swiper-container {
+    z-index: ${({ theme: { zIndex } }) => zIndex.feed};
+  }
+  .swiper-container,
+  .swiper-wrapper {
+    transition-duration: 600ms !important;
+  }
+  .swiper-slide {
+    width: 100%;
+    cursor: pointer;
+  }
+  .swiper-button-next,
+  .swiper-button-prev {
+  }
+`;
 const Ranking = styled.div`
   width: 100%;
   padding: 0 0 2rem 0;
@@ -105,13 +125,4 @@ export const Title = styled.div`
   letter-spacing: -0.8px;
   color: ${({ theme: { colors } }) => colors.darkGray};
   cursor: pointer;
-`;
-
-const CarouselBox = styled.div`
-  .flex-box {
-    display: flex;
-  }
-  .slider {
-    cursor: pointer;
-  }
 `;

--- a/src/components/Feed/Carousel.jsx
+++ b/src/components/Feed/Carousel.jsx
@@ -87,8 +87,9 @@ const CarouselBox = styled.div`
     width: 100%;
     cursor: pointer;
   }
-  .swiper-button-next,
-  .swiper-button-prev {
+  .swiper-button-next.swiper-button-disabled,
+  .swiper-button-prev.swiper-button-disabled {
+    pointer-events: auto;
   }
 `;
 const Ranking = styled.div`

--- a/src/components/Feed/Carousel.jsx
+++ b/src/components/Feed/Carousel.jsx
@@ -41,7 +41,6 @@ const CarouselComponent = React.memo(() => {
 
       <CarouselBox>
         <Swiper
-          key="carousel-swiper"
           slidesPerView={"auto"}
           centeredSlides={true}
           navigation={true}
@@ -57,7 +56,7 @@ const CarouselComponent = React.memo(() => {
         >
           {top5Tests &&
             top5Tests.map((test) => (
-              <SwiperSlide onClick={onClickTest}>
+              <SwiperSlide onClick={onClickTest} key={`slideKey_${test.uid}`}>
                 <ImageView
                   key={`key_${test.uid}`}
                   imageUrl={test.coverImg}

--- a/src/components/Header/LeftBtn.jsx
+++ b/src/components/Header/LeftBtn.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import styled from "styled-components";
-import { SVG } from "../common";
+import { NoticeAlert, SVG } from "../common";
 import usePage from "../../hooks/usePage";
 
-import { BACK, NOTHING } from "../../constants/headerInfo";
-
+import { BACK, NOTHING, SEARCH } from "../../constants/headerInfo";
+import ENUM from "../../constants/Enum";
 /*
  * type: string;
  */
@@ -14,6 +14,8 @@ const LeftBtn = ({ type = BACK }) => {
     switch (type) {
       case BACK:
         return goBack();
+      case SEARCH:
+        return NoticeAlert.open("곧 업데이트 예정이에요!");
       default:
         return null;
     }
@@ -22,11 +24,14 @@ const LeftBtn = ({ type = BACK }) => {
   if (type === NOTHING) return null;
 
   return (
-    <SVG
-      type={type}
-      onClick={onClickEvent}
-      style={{ width: "24", height: "24" }}
-    />
+    <>
+      <NoticeAlert icon={ENUM.WARNING} btns={[{ name: "닫기" }]} />
+      <SVG
+        type={type}
+        onClick={onClickEvent}
+        style={{ width: "24", height: "24" }}
+      />
+    </>
   );
 };
 

--- a/src/components/common/Loading.jsx
+++ b/src/components/common/Loading.jsx
@@ -22,6 +22,6 @@ const Container = styled.div`
   display: ${({ display }) => display};
 `;
 
-const StyledSpinner = styled(Spinner)`
+export const StyledSpinner = styled(Spinner)`
   color: ${({ theme: { colors } }) => colors.blue} !important;
 `;

--- a/src/redux/reducer/feedReducer.js
+++ b/src/redux/reducer/feedReducer.js
@@ -16,6 +16,11 @@ export const initState = {
   testsByTagError: false,
   testsByTag: [],
 
+  // 태그 바뀔 때 loading
+  changeTestsLoading: false,
+  // 무한 스크롤 loading
+  updateTestsLoading: false,
+
   lastTestUid: 0,
 };
 
@@ -42,29 +47,39 @@ const feed = createSlice({
     // 태그가 바뀌는 순간 요청 (기존 테스트들을 비워줘야함)
     changeTests: (state, { payload }) => {
       state.testsByTagLoading = true;
+      state.changeTestsLoading = true;
     },
     changeTestsSuccess: (state, { payload }) => {
       state.testsByTagLoading = false;
+      state.changeTestsLoading = false;
+
       state.testsByTag = payload;
       state.lastTestUid = state.testsByTag[state.testsByTag.length - 1].uid;
     },
     changeTestsError: (state, { payload }) => {
       state.testsByTagLoading = false;
       state.testsByTagError = true;
+
+      state.changeTestsLoading = false;
     },
 
     // 하나의 태그의 테스트 추가 요청 (무한 스크롤)
     updateTests: (state, { payload }) => {
       state.testsByTagLoading = true;
+      state.updateTestsLoading = true;
     },
     updateTestsSuccess: (state, { payload }) => {
       state.testsByTagLoading = false;
+      state.updateTestsLoading = false;
+
       state.testsByTag.push(...payload);
       state.lastTestUid = state.testsByTag[state.testsByTag.length - 1].uid;
     },
     updateTestsError: (state, { payload }) => {
       state.testsByTagLoading = false;
       state.testsByTagError = true;
+
+      state.updateTestsLoading = false;
     },
   },
 });

--- a/src/view/Feed.js
+++ b/src/view/Feed.js
@@ -43,55 +43,46 @@ const Feed = (props) => {
     window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
   }, [selected]);
 
+  if (feedLoading) return <Loading loading={feedLoading} />;
   return (
     <Container>
-      {feedLoading ? (
-        <Loading loading={feedLoading} />
-      ) : (
-        <>
-          <CarouselComponent />
-          <>
-            <TagContainer>
-              <TagSwiper
-                tags={tags}
-                selectedTag={selected}
-                setSelected={setSelected}
-              />
-            </TagContainer>
+      <CarouselComponent />
+      <TagContainer>
+        <TagSwiper
+          tags={tags}
+          selectedTag={selected}
+          setSelected={setSelected}
+        />
+      </TagContainer>
 
-            <CardContainer>
-              {/* <Nothing /> */}
-              {changeTestsLoading ? (
-                <SpinnerContainer>
-                  <StyledSpinner />
-                </SpinnerContainer>
-              ) : (
-                <InfinScroll
-                  datas={testsByTag}
-                  isStop={isStop}
-                  getMoreDatas={getMoreDatas}
-                >
-                  {testsByTag.map((test) => (
-                    <Card
-                      key={`test ${test.uid}`}
-                      title={test.title}
-                      coverImg={test.coverImg}
-                      makerName={test.maker.name}
-                      makerImg={test.makerImg}
-                      sharedCnt={test.sharedCnt}
-                      participatedCnt={test.participantsCnt}
-                      testLink={test.testLink}
-                    />
-                  ))}
-                </InfinScroll>
-              )}
-            </CardContainer>
-          </>
-          <BottomBtn
-            btnArr={[{ name: "테스트 만들기 도전!", type: PICKTEST }]}
-          />
-        </>
-      )}
+      <CardContainer>
+        {/* <Nothing /> */}
+        {changeTestsLoading ? (
+          <SpinnerContainer>
+            <StyledSpinner />
+          </SpinnerContainer>
+        ) : (
+          <InfinScroll
+            datas={testsByTag}
+            isStop={isStop}
+            getMoreDatas={getMoreDatas}
+          >
+            {testsByTag.map((test) => (
+              <Card
+                key={`test ${test.uid}`}
+                title={test.title}
+                coverImg={test.coverImg}
+                makerName={test.maker.name}
+                makerImg={test.makerImg}
+                sharedCnt={test.sharedCnt}
+                participatedCnt={test.participantsCnt}
+                testLink={test.testLink}
+              />
+            ))}
+          </InfinScroll>
+        )}
+      </CardContainer>
+      <BottomBtn btnArr={[{ name: "테스트 만들기 도전!", type: PICKTEST }]} />
     </Container>
   );
 };

--- a/src/view/Feed.js
+++ b/src/view/Feed.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import CarouselComponent from "../components/Feed/Carousel";
@@ -8,6 +8,8 @@ import { initFeed, updateTests } from "../redux/reducer/feedReducer";
 import TagSwiper from "../components/common/TagSwiper";
 import Card from "../components/Feed/Card";
 import InfinScroll from "../components/common/InfinScroll";
+import { Loading } from "../components/common";
+import { StyledSpinner } from "../components/common/Loading";
 
 const { PICKTEST } = ENUM;
 const Feed = (props) => {
@@ -20,6 +22,7 @@ const Feed = (props) => {
     testsByTagError,
     testsByTag,
     lastTestUid,
+    changeTestsLoading,
   } = useSelector((state) => state.feed);
 
   useEffect(() => {
@@ -37,12 +40,14 @@ const Feed = (props) => {
 
   useEffect(() => {
     // 태그 바뀔 때 스크롤 상단으로
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
   }, [selected]);
 
   return (
     <Container>
-      {feedLoading ? null : (
+      {feedLoading ? (
+        <Loading loading={feedLoading} />
+      ) : (
         <>
           <CarouselComponent />
           <>
@@ -55,24 +60,31 @@ const Feed = (props) => {
             </TagContainer>
 
             <CardContainer>
-              <InfinScroll
-                datas={testsByTag}
-                isStop={isStop}
-                getMoreDatas={getMoreDatas}
-              >
-                {testsByTag.map((test) => (
-                  <Card
-                    key={`test ${test.uid}`}
-                    title={test.title}
-                    coverImg={test.coverImg}
-                    makerName={test.maker.name}
-                    makerImg={test.makerImg}
-                    sharedCnt={test.sharedCnt}
-                    participatedCnt={test.participantsCnt}
-                    testLink={test.testLink}
-                  />
-                ))}
-              </InfinScroll>
+              {/* <Nothing /> */}
+              {changeTestsLoading ? (
+                <SpinnerContainer>
+                  <StyledSpinner />
+                </SpinnerContainer>
+              ) : (
+                <InfinScroll
+                  datas={testsByTag}
+                  isStop={isStop}
+                  getMoreDatas={getMoreDatas}
+                >
+                  {testsByTag.map((test) => (
+                    <Card
+                      key={`test ${test.uid}`}
+                      title={test.title}
+                      coverImg={test.coverImg}
+                      makerName={test.maker.name}
+                      makerImg={test.makerImg}
+                      sharedCnt={test.sharedCnt}
+                      participatedCnt={test.participantsCnt}
+                      testLink={test.testLink}
+                    />
+                  ))}
+                </InfinScroll>
+              )}
             </CardContainer>
           </>
           <BottomBtn
@@ -90,6 +102,9 @@ export default Feed;
 
 const Container = styled(PageContainer)`
   z-index: ${({ theme: { zIndex } }) => zIndex.feed};
+  .scroll-to-top {
+    opacity: 1;
+  }
 `;
 
 const TagContainer = styled.div`
@@ -100,4 +115,9 @@ const TagContainer = styled.div`
 
 const CardContainer = styled.div`
   margin-top: 2.8rem;
+`;
+
+const SpinnerContainer = styled.div`
+  text-align: center;
+  padding-top: 4rem;
 `;


### PR DESCRIPTION
## carousel
문제점: 기존 라이브러리(react-responsive-carousel) 캐러셀 사용 시 피드에서 다른 페이지 갔다가 뒤로간 후 캐러셀이 변화할 때 메모리 누수 발생
해결: 기존 라이브러리 삭제 후 태그,테스트 스와이퍼에서 사용했던 Swiper.js로 변경함 

## feed, tag
각각 loading 추가. 
다른 태그 선택 시 loading 처리 안해주고 먼저 선택된 태그의 데이터들에서 스크롤을하면 lastTestUid값이 선택할 태그의 데이터 요청값 으로 넘어가 버그아닌 버그(?)가 있었음. 그래서 선택할 태그의 데이터를 요청해서 받아오는 시간까지의 loading이 필요함. redux에도 태그만의 loading state를 추가

## 앞으로 해결해야 할 것
- [x] next-button disabled일 때 슬라이드 클릭되서 페이지 이동 문제 해결
- [ ] next-button custom
- [ ] 실제 배포 후 데이터가 없을 때 -> 더 정확한 디자인 요구
- [ ] infinscroll -> 마지막 데이터 구분
