### PR TITLE
[fix] 얼럿창 뜨지 않는 이슈 처리 (router 이동시 메모리 lack 에러)

### DIFF
--- a/src/components/Header/LeftBtn.jsx
+++ b/src/components/Header/LeftBtn.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { NoticeAlert, SVG } from "../common";
 import usePage from "../../hooks/usePage";
 
@@ -9,6 +9,7 @@ import ENUM from "../../constants/Enum";
  */
 const LeftBtn = ({ type = BACK }) => {
   const { goBack } = usePage();
+
   const onClickEvent = () => {
     switch (type) {
       case BACK:
@@ -24,7 +25,9 @@ const LeftBtn = ({ type = BACK }) => {
 
   return (
     <>
-      <NoticeAlert icon={ENUM.WARNING} btns={[{ name: "닫기" }]} />
+      {type !== BACK && (
+        <NoticeAlert icon={ENUM.WARNING} btns={[{ name: "닫기" }]} />
+      )}
       <SVG
         type={type}
         onClick={onClickEvent}

--- a/src/components/common/NoticeAlert.jsx
+++ b/src/components/common/NoticeAlert.jsx
@@ -60,7 +60,7 @@ class NoticeAlert extends PureComponent {
 
   render() {
     const { open, content, mode } = this.state;
-    const { icon, btns } = this.props;
+    const { icon, btns, shareInfo = {} } = this.props;
 
     if (!open) return null;
 
@@ -73,7 +73,10 @@ class NoticeAlert extends PureComponent {
             {mode === SHARE ? (
               <>
                 <AlertText>친구한테 공유할래요!</AlertText>
-                <BtnShare onClick={this.handleShareClick} />
+                <BtnShare
+                  shareInfo={shareInfo}
+                  onClick={this.handleShareClick}
+                />
               </>
             ) : (
               <>

--- a/src/components/common/NoticeAlert.jsx
+++ b/src/components/common/NoticeAlert.jsx
@@ -8,15 +8,12 @@ import BtnShare from "./BtnShare";
 
 const { SHARE } = ENUM;
 let that = null; // 정적 메소드용
+const initState = { open: false, content: "", mode: null };
 
 class NoticeAlert extends PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      open: false,
-      content: "",
-      mode: null,
-    };
+    this.state = initState;
     that = this;
   }
 
@@ -36,7 +33,7 @@ class NoticeAlert extends PureComponent {
     this.handleOnClose();
   };
 
-  handleOnClose = () => this.setState({ open: false });
+  handleOnClose = () => this.setState({ ...initState, open: false });
 
   setButtons() {
     const { btns } = this.props;


### PR DESCRIPTION
## router 변경 시, LeftBtn 얼럿이 뜨지 않는 이슈

![image](https://user-images.githubusercontent.com/18224086/120877328-e46b6b00-c5f0-11eb-9044-ae19ef9964ff.png)

- 이슈 현상: 라우터 변경 후 다시 돌아왔을 때, NoticeAlert 컴포넌트가 뜨지 않는 현상
- 이슈 원인: 메모리 lack 에러 발생
```
- feed 화면 내 LeftBtn에서 NoticeAlert 사용 & 다음 페이지인 welcome 화면도 사용 중인 상태
- welcome에서 feed로 돌아왔을 때, LeftBtn에서는 변화가 없으므로 NoticeAlert 렌더를 타지 않음
- 하지만 welcome에서 NoticeAlert 컴포넌트 마운트 해제(Unmount)한 상태
```

- 참조 : [router 이동시 메모리 lack 에러 - cleanup 을 통해 해결하라!!](https://kyounghwan01.github.io/blog/React/cant-perform-a-React-state-update-on-an-unmounted-component/#%E1%84%87%E1%85%A1%E1%86%AF%E1%84%89%E1%85%A2%E1%86%BC-%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%B2)