### PR TITLE
Feature/testing loading api

### DIFF
--- a/src/components/common/TagSwiper.jsx
+++ b/src/components/common/TagSwiper.jsx
@@ -3,7 +3,13 @@ import styled from "styled-components";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Tag } from ".";
 
-const TagSwiper = ({ tags, selectedTag, selectable = false, noPadding }) => {
+const TagSwiper = ({
+  tags,
+  selectedTag,
+  selectable = false,
+  allSelected = false,
+  noPadding,
+}) => {
   const resultTag = selectedTag === "" ? "전체" : selectedTag;
   return (
     <Container noPadding={noPadding}>
@@ -13,7 +19,7 @@ const TagSwiper = ({ tags, selectedTag, selectable = false, noPadding }) => {
             <Tag
               key={`${tag}-${idx}`}
               tag={tag}
-              selected={resultTag === tag}
+              selected={allSelected || resultTag === tag}
               selectable={selectable}
             />
           ))}

--- a/src/components/frame/Testing.jsx
+++ b/src/components/frame/Testing.jsx
@@ -35,7 +35,7 @@ const Testing = ({
 
   useEffect(() => {
     if (checkModule) {
-      dispatch(setLoading(true));
+      if (module !== otherType) dispatch(setLoading(true));
       //call api at didmount
       switch (module) {
         case welcome: // 웰컴

--- a/src/components/frame/Testing.jsx
+++ b/src/components/frame/Testing.jsx
@@ -30,9 +30,11 @@ const Testing = ({
   const { testid, resultid } = queryString.parse(location.search);
   const { loading, isError } = useSelector((state) => state.common);
   const dispatch = useDispatch();
+  const checkModule =
+    testid || (resultid && [result, otherType].includes(module));
 
   useEffect(() => {
-    if (testid || (resultid && module === result)) {
+    if (checkModule) {
       dispatch(setLoading(true));
       //call api at didmount
       switch (module) {
@@ -56,10 +58,7 @@ const Testing = ({
 
   if (loading) return <Loading loading={loading} />;
 
-  if (
-    !isError &&
-    (testid || (resultid && [result, otherType].includes(module)))
-  ) {
+  if (!isError && checkModule) {
     switch (module) {
       case welcome: // 웰컴
         return <Welcome />;

--- a/src/components/frame/Testing.jsx
+++ b/src/components/frame/Testing.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { withRouter } from "react-router-dom";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import queryString from "query-string";
 import Welcome from "../../view/testing/Welcome";
 import Comments from "../../view/testing/Comments";
@@ -15,9 +15,11 @@ import {
   result,
   otherType,
 } from "../../constants/urlInfo";
-import { setTestID, getTestExam } from "../../redux/reducer/testingReducer";
+import { Loading } from "../common";
+import { setLoading, setError } from "../../redux/reducer/commonReducer";
+import { getTestInfo, getTestExam } from "../../redux/reducer/testingReducer";
 import { getReplyInfo } from "../../redux/reducer/replyReducer";
-import { setTestResultID } from "../../redux/reducer/resultReducer";
+import { getTestResultInfo } from "../../redux/reducer/resultReducer";
 
 const Testing = ({
   match: {
@@ -26,23 +28,25 @@ const Testing = ({
   location,
 }) => {
   const { testid, resultid } = queryString.parse(location.search);
+  const { loading, isError } = useSelector((state) => state.common);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    //call api at didmount
     if (testid || (resultid && module === result)) {
+      dispatch(setLoading(true));
+      //call api at didmount
       switch (module) {
         case welcome: // 웰컴
-          dispatch(setTestID(testid));
+          dispatch(getTestInfo(testid));
           break;
         case comments: // 댓글
           dispatch(getReplyInfo({ testid, timestamp: 0 }));
           break;
         case exam: // 테스트
-          dispatch(getTestExam({ testID: testid }));
+          dispatch(getTestExam(testid));
           break;
         case result: // (module)
-          dispatch(setTestResultID(resultid));
+          dispatch(getTestResultInfo(resultid));
           break;
         default:
           break;
@@ -50,20 +54,27 @@ const Testing = ({
     }
   }, [dispatch, module, testid, resultid]);
 
-  switch (module) {
-    case welcome: // 웰컴
-      return <Welcome />;
-    case comments: // 댓글
-      return <Comments />;
-    case exam: // 테스트
-      return <Exam />;
-    case result: // 테스트결과 (module)
-      return <Result />;
-    case otherType: // 다른유형 전체보기
-      return <OtherType />;
-    default:
-      console.warn("where are you?", module);
-      break;
+  if (loading) return <Loading loading={loading} />;
+
+  if (
+    !isError &&
+    (testid || (resultid && [result, otherType].includes(module)))
+  ) {
+    switch (module) {
+      case welcome: // 웰컴
+        return <Welcome />;
+      case comments: // 댓글
+        return <Comments />;
+      case exam: // 테스트
+        return <Exam />;
+      case result: // 테스트결과 (module)
+        return <Result />;
+      case otherType: // 다른유형 전체보기
+        return <OtherType />;
+      default:
+        console.warn("where are you?", module);
+        break;
+    }
   }
 
   return <Error />;

--- a/src/constants/testingState.js
+++ b/src/constants/testingState.js
@@ -32,94 +32,27 @@ export const replyForm = {
 };
 
 const testing = {
-  current_testID: "",
+  current_testID: null,
   testInfo: {
     uid: "",
-    title: "성격 유형검사 MBTI Test",
-    description:
-      "총 검사 시간은 12분 내외입니다. 혹 질문이 마음에 들지 않더라도 정직하게 답변하십시오. 가능하면 답변 시 '중립'을 선택하지 마십시오. ",
-    coverImg: "https://google.storage/path/to/img",
+    title: "",
+    description: "",
+    coverImg: "",
     maker: {
-      name: "메이커짱짱",
+      name: "",
       userUid: "",
     },
-    optionalURL: "this_is_url_to_share",
-    participantsCnt: 3258,
-    repliesCnt: 879,
-    testLink: "https://my-app.test/1",
-    tags: ["성격테스트", "우정테스트"],
+    optionalURL: "",
+    participantsCnt: 0,
+    repliesCnt: 0,
+    testLink: "",
+    tags: [],
   },
-  questsCnt: 2,
-  questions: [
-    {
-      question:
-        "내가 좋아하는 여행시는 어디일까요?\n2주일 때는 아래로 내려주세요.",
-      img: "string",
-      options: [
-        {
-          name: "보라카이",
-        },
-        {
-          name: "제주도",
-        },
-        {
-          name: "스페인",
-        },
-      ],
-    },
-    {
-      question: "string",
-      img: "string",
-      options: [
-        {
-          name: "string",
-        },
-        {
-          name: "string",
-        },
-        {
-          name: "string",
-        },
-      ],
-    },
-  ],
+  questsCnt: 0,
+  questions: [],
   /* 정답 형식 */
   answers: { type: "multi", values: [] },
-  recent3replies: [
-    {
-      uid: "nz6eCHZ2GZJeor6BXJDC",
-      content: "테스트 진짜 신박해요~!! ㅋㅋㅋ 우오아아 재밌다",
-      writtenAt: 1622009843765,
-      writer: {
-        uid: 34234,
-        isMe: 0,
-        profileImg: "https://~~",
-        nickname: "jennny",
-      },
-    },
-    {
-      uid: "nz6eCHZ2GZJeor6BXJDC",
-      content: "2줄 테스트 진자 신박해요",
-      writtenAt: 1622009495898,
-      writer: {
-        uid: 34234,
-        isMe: 0,
-        profileImg: "https://~~",
-        nickname: "jennny",
-      },
-    },
-    {
-      uid: "nz6eCHZ2GZJeor6BXJDC",
-      content: "3줄 테스트 진자 신박해요",
-      writtenAt: 1619324817995,
-      writer: {
-        uid: 34234,
-        isMe: 0,
-        profileImg: "https://~~",
-        nickname: "jennny",
-      },
-    },
-  ],
+  recent3replies: [],
 };
 
 const reply = {
@@ -129,69 +62,27 @@ const reply = {
 };
 
 const resultForm = {
-  cnt: 4,
-  description:
-    "질문이 모두 끝났군요. 구분용입니다. 혹 질문이 마음에 들지 않더라도 정직하게 답변하십시오. 가능하면 답변 시 '중립'을 선택하지 마십시오.",
-  img: "결과 이미지 path2",
-  percent: 27,
-  pointBound: { start: 5, end: 7 },
-  title: "결과 타이틀2",
+  cnt: 0,
+  description: "",
+  img: "",
+  percent: 0,
+  pointBound: { start: 0, end: 0 },
+  title: "",
 };
 
 /* 객관식 테스트 결과 */
 const result = {
   isRankMode: false,
-  responseUid: "faf8747c-b07b-4541-93e3-d094d0d014d0",
-  userTestResult: "결과 타이틀2",
-  testResults: [
-    resultForm,
-    {
-      img: "결과 이미지 path",
-      description:
-        "총 검사 시간은 12분 내외입니다. 혹 질문이 마음에 들지 않더라도 정직하게 답변하십시오. 가능하면 답변 시 '중립'을 선택하지 마십시오.",
-      title: "당신은 센스로 무장했어요",
-      pointBound: { end: 4, start: 0 },
-      cnt: 0,
-      percent: 58,
-    },
-    {
-      img: "결과 이미지 path",
-      description: "결과 설명",
-      title: "결과 타이틀",
-      pointBound: { end: 4, start: 0 },
-      cnt: 0,
-      percent: 0,
-    },
-  ],
-  repliesCnt: 13,
+  responseUid: "",
+  userTestResult: "",
+  testResults: [resultForm],
+  repliesCnt: 0,
   recent3Replies: [],
   currentResult: resultForm,
-  results: [
-    // rank 높은 순대로
-    {
-      nickname: "찐친",
-      score: 20,
-    },
-    {
-      nickname: "찐친",
-      score: 20,
-    },
-    {
-      nickname: "찐친",
-      score: 20,
-    },
-    {
-      nickname: "찐친",
-      score: 20,
-    },
-    {
-      nickname: "찐친",
-      score: 19,
-    },
-  ],
+  results: [],
   feedback: {
-    emoji: "happy",
-    msg: "오 너님 좀 잘 만드신듯 ㅋㅋ",
+    emoji: "",
+    msg: "",
   },
 };
 

--- a/src/redux/reducer/commonReducer.js
+++ b/src/redux/reducer/commonReducer.js
@@ -4,6 +4,8 @@ const prefix = "common";
 
 export const commonInitState = {
   headTitle: "",
+  loading: false,
+  isError: null,
 };
 
 const common = createSlice({
@@ -16,10 +18,16 @@ const common = createSlice({
     setHeadTitle: (state, { payload }) => {
       state.headTitle = payload;
     },
+    setLoading: (state, { payload }) => {
+      state.loading = payload;
+    },
+    setError: (state, { payload }) => {
+      state.isError = payload;
+    },
   },
 });
 
 //actions
-export const { setHeadTitle } = common.actions;
+export const { setHeadTitle, setLoading, setError } = common.actions;
 
 export default common;

--- a/src/redux/reducer/replyReducer.js
+++ b/src/redux/reducer/replyReducer.js
@@ -11,6 +11,9 @@ const reply = createSlice({
       //recent3replies
       state.testUid = testid;
     },
+    getReplyInfoSuccess: (state, { payload }) => {
+      state.replies.push(...payload);
+    },
     moreReplyInfo: (state, { payload: { testid } }) => {},
     addReplyInfo: (state, { payload }) => {
       state.replies.push(...payload);

--- a/src/redux/reducer/resultReducer.js
+++ b/src/redux/reducer/resultReducer.js
@@ -7,9 +7,20 @@ const result = createSlice({
   name: prefix,
   initialState: initState.result,
   reducers: {
-    setTestResultID: (state, { payload }) => {
+    getTestResultInfo: (state, { payload }) => {
       state.responseUid = payload;
     },
+    getTestResultInfoSuccess: (state, { payload }) => {
+      console.log("updateTestResult!!!", payload);
+      state = Object.assign(state, payload);
+
+      if (payload.userTestResult) {
+        state.currentResult = payload.testResults.find((resultForm) => {
+          return resultForm.title === payload.userTestResult;
+        });
+      }
+    },
+    getTestResultInfoError: (state, { payload }) => {},
     updateTestResult: (state, { payload }) => {
       console.log("updateTestResult", payload);
       state = Object.assign(state, payload);
@@ -28,7 +39,9 @@ const result = createSlice({
 });
 
 export const {
-  setTestResultID,
+  getTestResultInfo,
+  getTestResultInfoSuccess,
+  getTestResultInfoError,
   updateTestResult,
   getTestResult,
 } = result.actions;

--- a/src/redux/reducer/testingReducer.js
+++ b/src/redux/reducer/testingReducer.js
@@ -7,24 +7,34 @@ const testing = createSlice({
   name: prefix,
   initialState: initState.testing,
   reducers: {
-    setTestID: (state, { payload }) => {
+    //#region : welcome
+    getTestInfo: (state, { payload }) => {
       state.current_testID = payload;
     },
+    getTestInfoSuccess: (state, { payload }) => {
+      state.testInfo = payload.testDoc;
+      state.recent3replies = payload.recent3replies;
+    },
+    getTestInfoError: (state, { payload }) => {
+      state.current_testID = null;
+    },
+    //#endregion
     updateTestInfo: (state, { payload: { testInfo, recent3replies } }) => {
       state.testInfo = testInfo;
       state.recent3replies = recent3replies;
     },
-    getTestExam: (state, { payload: { testID, testType } }) => {
-      if (state.current_testID !== testID) {
+    getTestExam: (state, { payload }) => {
+      if (state.current_testID !== payload) {
         console.log("현재 페이지가 아님!");
-        state.current_testID = testID;
+        state.current_testID = payload;
       }
       state.answers.type = "multi"; //testType
     },
-    updateTestExam: (state, { payload: { questions } }) => {
+    getTestExamSuccess: (state, { payload: { questions } }) => {
       state.questions = questions;
       state.questsCnt = questions.length;
     },
+    getTestExamError: (state, { payload }) => {},
     saveAnwerByStep: (state, { payload: { page, value } }) => {
       if (state.answers.values.length > page)
         state.answers.values[page] = value;
@@ -44,10 +54,13 @@ const testing = createSlice({
 });
 
 export const {
-  setTestID,
+  getTestInfo,
+  getTestInfoSuccess,
+  getTestInfoError,
   updateTestInfo,
   getTestExam,
-  updateTestExam,
+  getTestExamSuccess,
+  getTestExamError,
   saveAnwerByStep,
   saveResult,
 } = testing.actions;

--- a/src/redux/saga/replySaga.js
+++ b/src/redux/saga/replySaga.js
@@ -16,23 +16,48 @@ import {
   moreReplyInfo,
   stopCallComments,
 } from "../reducer/replyReducer";
+import { setLoading, setError } from "../reducer/commonReducer";
 import testingAPI from "../../api/testingAPI";
-import { SUCCESS } from "../../utils/asyncUtils";
+import { createActionString, SUCCESS } from "../../utils/asyncUtils"; //createPromiseSaga
+
+//#region >> 테스트 정보 불러오기 (welcome)
+// const getComments = createPromiseSaga(
+//   getTestInfo.type,
+//   testingAPI.getTestInfo
+// );
+
+// function* getTestInformSuccess() {
+//   //로딩바 닫기
+//   yield put({ type: setLoading.type, payload: false });
+// }
+
+// function* getTestInformError() {
+//   //로딩바 닫기 및 오류 화면 표시
+//   yield put({ type: setError.type, payload: true });
+//   yield put({ type: setLoading.type, payload: false });
+// }
+//#endregion
 
 function* getComments(action) {
   const state = yield select();
   const param = action.payload;
   const testID = param.testid ? param.testid : state.reply.testUid;
+  const { success, error } = createActionString(action.type);
+
   const { data, status } = yield call(
     testingAPI.getReplyInfo,
     testID,
     param.timestamp
   );
 
+  //로딩바 닫기
+  if (state.common.loading)
+    yield put({ type: setLoading.type, payload: false });
+
   if (status === SUCCESS) {
     if (data?.length > 0) {
       yield put({
-        type: addReplyInfo.type,
+        type: success,
         payload: data,
       });
     } else {
@@ -41,6 +66,9 @@ function* getComments(action) {
         payload: true,
       });
     }
+  } else {
+    //오류 화면 표시
+    yield put({ type: setError.type, payload: true });
   }
 }
 

--- a/src/redux/saga/resultSaga.js
+++ b/src/redux/saga/resultSaga.js
@@ -1,9 +1,32 @@
 import { call, put, fork, all, takeLeading } from "redux-saga/effects";
-import { setTestResultID, updateTestResult } from "../reducer/resultReducer";
+import {
+  getTestResultInfo,
+  getTestResultInfoSuccess,
+  getTestResultInfoError,
+  updateTestResult,
+} from "../reducer/resultReducer";
+import { setLoading, setError } from "../reducer/commonReducer";
 import testingAPI from "../../api/testingAPI";
-import { SUCCESS } from "../../utils/asyncUtils"; //createPromiseSaga
+import { createPromiseSaga, SUCCESS } from "../../utils/asyncUtils"; //createPromiseSaga
 
-function* getResultInform(action) {
+const getResultInform = createPromiseSaga(
+  getTestResultInfo.type,
+  testingAPI.getResultInfo
+);
+
+function* getResultInformSuccess(action) {
+  //로딩바 닫기
+  yield put({ type: setLoading.type, payload: false });
+}
+
+function* getResultInformError() {
+  //로딩바 닫기 및 오류 화면 표시
+  yield put({ type: setError.type, payload: true });
+  yield put({ type: setLoading.type, payload: false });
+}
+//#endregion
+
+function* getResultInform1(action) {
   const param = action.payload;
   const { data, status } = yield call(testingAPI.getResultInfo, param);
 
@@ -30,7 +53,9 @@ function* getResultInform(action) {
 }
 
 function* getResultInfromation() {
-  yield takeLeading(setTestResultID.type, getResultInform);
+  yield takeLeading(getTestResultInfo.type, getResultInform);
+  yield takeLeading(getTestResultInfoSuccess.type, getResultInformSuccess);
+  yield takeLeading(getTestResultInfoError.type, getResultInformError);
   // yield takeLeading(getTestResult.type, get)
 }
 

--- a/src/redux/saga/resultSaga.js
+++ b/src/redux/saga/resultSaga.js
@@ -3,16 +3,47 @@ import {
   getTestResultInfo,
   getTestResultInfoSuccess,
   getTestResultInfoError,
-  updateTestResult,
 } from "../reducer/resultReducer";
 import { setLoading, setError } from "../reducer/commonReducer";
 import testingAPI from "../../api/testingAPI";
 import { createPromiseSaga, SUCCESS } from "../../utils/asyncUtils"; //createPromiseSaga
 
-const getResultInform = createPromiseSaga(
-  getTestResultInfo.type,
-  testingAPI.getResultInfo
-);
+// const getResultInform = createPromiseSaga(
+//   getTestResultInfo.type,
+//   testingAPI.getResultInfo
+// );
+
+//#region > 테스트 결과 가져오기
+function* getResultInform(action) {
+  const param = action.payload;
+  const { data, status } = yield call(testingAPI.getResultInfo, param);
+
+  if (status === SUCCESS && data.testResults.length > 0) {
+    const {
+      isRankMode,
+      recent3Replies,
+      repliesCnt,
+      testResults,
+      userTestResult,
+    } = data;
+
+    yield put({
+      type: getTestResultInfoSuccess.type,
+      payload: {
+        isRankMode,
+        recent3Replies,
+        repliesCnt,
+        testResults,
+        userTestResult,
+      },
+    });
+  } else {
+    yield put({
+      type: getTestResultInfoError.type,
+      payload: data,
+    });
+  }
+}
 
 function* getResultInformSuccess(action) {
   //로딩바 닫기
@@ -25,32 +56,6 @@ function* getResultInformError() {
   yield put({ type: setLoading.type, payload: false });
 }
 //#endregion
-
-function* getResultInform1(action) {
-  const param = action.payload;
-  const { data, status } = yield call(testingAPI.getResultInfo, param);
-
-  if (status === SUCCESS) {
-    const {
-      isRankMode,
-      recent3Replies,
-      repliesCnt,
-      testResults,
-      userTestResult,
-    } = data;
-
-    yield put({
-      type: updateTestResult.type,
-      payload: {
-        isRankMode,
-        recent3Replies,
-        repliesCnt,
-        testResults,
-        userTestResult,
-      },
-    });
-  }
-}
 
 function* getResultInfromation() {
   yield takeLeading(getTestResultInfo.type, getResultInform);

--- a/src/redux/saga/testingSaga.js
+++ b/src/redux/saga/testingSaga.js
@@ -83,7 +83,7 @@ function* moveResultPage(action) {
     payload: { responseUid },
   } = action;
 
-  yield (window.location.href = `${window.location.origin}/testing/result?resultid=${responseUid}`);
+  yield (window.location.replace(`${window.location.origin}/testing/result?resultid=${responseUid}`));
 }
 //#endregion
 

--- a/src/view/testing/Exam.jsx
+++ b/src/view/testing/Exam.jsx
@@ -53,7 +53,8 @@ const Exam = memo((props) => {
 
   useEffect(() => {
     //헤더 타이틀 변경
-    dispatch(setHeadTitle(`${page + 1}/${questsCnt}`));
+    const title = questsCnt > 0 ? `${page + 1}/${questsCnt}` : "";
+    dispatch(setHeadTitle(title));
   }, [dispatch, page, questsCnt]);
 
   const onClickAnswer = (idx, value, event) => {
@@ -75,14 +76,20 @@ const Exam = memo((props) => {
     }
   };
 
-  const PageComponent = () => (
-    <Page
-      page={page}
-      answers={answers}
-      questions={questions[page]}
-      onClick={onClickAnswer}
-    />
-  );
+  const PageComponent = () => {
+    if (questions?.length > 0) {
+      return (
+        <Page
+          page={page}
+          answers={answers}
+          questions={questions[page]}
+          onClick={onClickAnswer}
+        />
+      );
+    } else {
+      return null;
+    }
+  };
 
   return (
     <div style={{ padding: "10px 2rem" }}>

--- a/src/view/testing/OtherType.jsx
+++ b/src/view/testing/OtherType.jsx
@@ -31,6 +31,7 @@ const OtherType = ({ otherType }) => {
         {testResults?.map(({ title, percent, img, description }, idx) => {
           return (
             <TestInform
+              key={`OtherType_${idx}`}
               rank={idx + 1}
               title={title}
               percent={percent}

--- a/src/view/testing/SubComponents/TestIntro.jsx
+++ b/src/view/testing/SubComponents/TestIntro.jsx
@@ -43,7 +43,7 @@ const TestIntro = memo((props) => {
       </InfoImg>
       {tags?.length > 0 && (
         <TagContainer>
-          <TagSwiper tags={tags} noPadding />
+          <TagSwiper tags={tags} allSelected noPadding />
         </TagContainer>
       )}
       <Inform>

--- a/src/view/testing/Welcome.jsx
+++ b/src/view/testing/Welcome.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { useSelector } from "react-redux";
-import { BtnShare, NoticeAlert } from "../../components/common";
+import { NoticeAlert } from "../../components/common";
 import BottomBtn, { PageContainer } from "../../components/frame/BottomBtn";
 import TestIntro from "./SubComponents/TestIntro";
 import RoundContiner from "./SubComponents/RoundContainer";
@@ -21,12 +21,18 @@ const returnALInfo = (type, callback) => {
 
   if (type === "report") {
     result = {
+      msg: "이 테스트를 신고할까요?",
       btn: [{ name: "돌아가기" }, { name: "신고하기", callback }],
     };
   } else if (type === SHARE) {
     result = {
       msg: "친구한테 공유할래요!",
-      component: <BtnShare />,
+      showInfo: {
+        link: "",
+        title: "",
+        description: "TEST",
+        imageUrl: "",
+      },
       btn: [{ name: SHARE, callback }],
     };
   }
@@ -48,16 +54,15 @@ const Welcome = () => {
   });
 
   const openAlert = (type) => {
-    const msg =
-      type === SHARE ? "친구한테 공유할래요!" : "이 댓글을 신고할까요?";
     const alert_info = Object.assign(
       {},
       def_alert,
       returnALInfo(type, handleOnAlertClick)
     );
-    setALInfo(alert_info);
-    NoticeAlert.open(msg, SHARE);
+    setALInfo(alert_info); //얼럿에 띄울 정보
+    NoticeAlert.open(alert_info.msg, SHARE);
   };
+
   const handleOnAlertClick = useCallback((id, event) => {
     // 선택한 버튼명 반환
     console.log(id, "클릭되었습니다!");


### PR DESCRIPTION
# 자연스러운 UX 동작을 위해 수정

### 화면 이동 시, 데이터 조회 (API) 할 때 로딩바 추가를 위해 reducer / saga 변경

테스팅 페이지 같은 경우 모두 조회 api를 통해 진입이 가능하므로 로딩바를 Testing.jsx 에서 띄웁니다.
(테스팅 페이지 시작 컴포넌트인 Testing.jsx 에서 일괄 관리)

테스팅이 끝났을 때, POST API 호출/지연 시간이 있으므로 여러번 클릭하지 못하도록 로딩바 추가했습니다.

### reducer & saga
이전에 @1000peach 가 코드 리뷰에서 말한 내용 처럼 `createPromiseSaga` 를 사용하여 가독성을 높였습니다.
사용하니깐 소스가 더 깔끔하게 이해하기 편하네요!

### useUser 편해요!
댓글에서는 사용자가 회원 여부가 필요해서 활용해서 추가 했습니다.

### 공통 컴포넌트 TagSwiper props 추가
Welcome 페이지에서는 태그가 모두 파랑색으로 표시되어 예외로 props 추가했어요!