### PR TITLE
[fix] 로그인 후 페이지 이동 로직 추가 (이전 페이지로 이동)

### DIFF
--- a/src/components/frame/Drawer.js
+++ b/src/components/frame/Drawer.js
@@ -17,6 +17,7 @@ const logoSvgStyle = {
 
 const Drawer = ({ onClose }) => {
   const { loggedIn, logOut } = useUser();
+  const { pathname, search } = window.location;
 
   return (
     <Dimmed>
@@ -49,7 +50,10 @@ const Drawer = ({ onClose }) => {
             </Item>
           ) : (
             <Item>
-              <Link to="/login" className="menu">
+              <Link
+                to={{ pathname: "/login", state: { from: pathname, search } }}
+                className="menu"
+              >
                 로그인
               </Link>
             </Item>

--- a/src/hooks/usePage.js
+++ b/src/hooks/usePage.js
@@ -2,6 +2,7 @@ import { useHistory } from "react-router";
 
 const usePage = () => {
   const history = useHistory();
+  const { location } = history;
 
   const replace = (pathname, search = null, state = null) => {
     history.replace({
@@ -23,7 +24,7 @@ const usePage = () => {
   const go = () => history.go(); // go front
   const goBack = () => history.goBack(); // go back
 
-  return { goPage, go, goBack, replace };
+  return { location, goPage, go, goBack, replace };
 };
 
 export default usePage;

--- a/src/view/login/Login.jsx
+++ b/src/view/login/Login.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import KaKaoLogin from "react-kakao-login";
 import styled from "styled-components";
 
@@ -12,9 +12,18 @@ import kakao from "../../resources/images/kakaoSm.png";
 
 const Login = () => {
   const { loggedIn, kakaoLogIn } = useUser();
-  const { replace } = usePage();
+  const { location, replace } = usePage();
 
-  if (loggedIn) replace("/");
+  useEffect(() => {
+    if (loggedIn) {
+      if (location.state && location.state.hasOwnProperty("from")) {
+        const { from, search = "" } = location.state;
+        replace(from, search);
+      } else {
+        replace("/");
+      }
+    }
+  }, [loggedIn]);
 
   const onSuccessKakao = async (resData) => {
     const {


### PR DESCRIPTION
# 로그인 후 페이지 이동 로직 수정

before : 무조건 피드 화면으로 이동한다.
after: 오늘의 테스트 페이지(피드, 웰컴, 댓글, 결과 등)에서 로그인 시도한 페이지로 이동한다.

histroy 객체 내 location 안에 `state`라는 저장 값을 활용했어요!

drawer 내[ Link 컴포넌트](https://reactrouter.com/web/api/Link)에서 로그인 페이지 이동 직전, state 값에 `로그인 시도한 페이지 정보`를 저장해요!

```javascript
state: {
   from: 페이지 pathname,
   search: queryString (테스팅에선 필수 값)
}
```

아래 이슈 해결합니다 :)

- [x] 회원가입 후 해당 댓글 페이지가 아니라 피드로 이동됨
