### PR TITLE
[fix] 댓글 영역 배경 고정

### DIFF
--- a/src/view/testing/SubComponents/RoundContainer.jsx
+++ b/src/view/testing/SubComponents/RoundContainer.jsx
@@ -10,6 +10,7 @@ const RoundBox = styled.div`
   background: ${({ theme: { colors } }) => colors.snow};
   border-radius: 25px 25px 0px 0px;
   width: 100%;
+  flex: 1;
   /*24px 20px*/
   padding: ${({ noPadding, theme: { paddings } }) =>
     noPadding ? "0px" : "24px " + paddings.main + "rem 0px;"};

--- a/src/view/testing/Welcome.jsx
+++ b/src/view/testing/Welcome.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from "react";
 import { useSelector, useDispatch } from "react-redux";
+import styled from "styled-components";
 import { NoticeAlert } from "../../components/common";
 import BottomBtn, { PageContainer } from "../../components/frame/BottomBtn";
 import TestIntro from "./SubComponents/TestIntro";
@@ -76,7 +77,7 @@ const Welcome = () => {
   };
 
   return (
-    <PageContainer>
+    <Container>
       {/* 테스트 상세 정보 */}
       <TestIntro openAlert={openAlert} />
       {/* 댓글 영역 */}
@@ -108,8 +109,13 @@ const Welcome = () => {
         }}
         onShareClick={handleShareClick}
       />
-    </PageContainer>
+    </Container>
   );
 };
+
+const Container = styled(PageContainer)`
+  display: flex;
+  flex-direction: column;
+`;
 
 export default Welcome;


### PR DESCRIPTION
## 작업 내용

![image](https://user-images.githubusercontent.com/36118545/122277457-e0104d80-cf20-11eb-9f25-7ee2a1c2451c.png)

댓글 수가 적어도 아래 부분을 차지해서 배경색이 보이도록 css를 수정했습니다.
확인 후 이상 없으면 `Testing-second-add` 브랜치에 머지해도 될 거 같아요!