### PR TITLE
마이페이지 2차 MVP 추가 기능

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom-confetti": "^0.2.0",
     "react-helmet": "^6.1.0",
     "react-infinite-scroll-component": "^6.1.0",
+    "react-input-autosize": "^3.0.0",
     "react-kakao-login": "^2.1.0",
     "react-redux": "^7.2.3",
     "react-router": "^5.2.0",

--- a/src/api/userAPI.js
+++ b/src/api/userAPI.js
@@ -1,4 +1,4 @@
-import { get, post } from "./instance";
+import { get, post, put } from "./instance";
 
 export default class UserAPI {
   static refreshToken() {
@@ -36,5 +36,17 @@ export default class UserAPI {
   // 임시 저장 테스트
   static tempSaveTests() {
     return get("me/test/saved");
+  }
+  // 프로필 업로드
+  static uploadImg(form) {
+    return post("/img", form);
+  }
+  // 프로필 변경
+  static updateProfile(params) {
+    return put("/me/profile-img", params);
+  }
+  // 닉네임 변경
+  static updateNickname(params) {
+    return put("/me/nickname", params);
   }
 }

--- a/src/components/MyPage/ManageList.jsx
+++ b/src/components/MyPage/ManageList.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import styled from "styled-components";
+import SVG from "../common/SVG";
+import ENUM, { CHANGEPW, CHECKTERMS, DELETEACCOUT } from "../../constants/Enum";
+import { useCallback } from "react";
+
+const ManageList = (props) => {
+  const list = [CHANGEPW, CHECKTERMS, DELETEACCOUT];
+  const onClick = useCallback((li) => {
+    switch (li) {
+      case CHANGEPW:
+        // 페이지 이동
+        break;
+      case CHECKTERMS:
+        // 페이지 이동
+        break;
+      case DELETEACCOUT:
+        // 페이지 이동
+        break;
+
+      default:
+        break;
+    }
+    return;
+  });
+  return (
+    <Menu>
+      {list.map((li) => (
+        <Item key={li}>
+          <div>{li}</div>
+          <div className="svg-box">
+            <SVG
+              type={ENUM.NEXT}
+              style={{
+                width: "20",
+                height: "20",
+              }}
+              onClick={onClick.bind(this, li)}
+            />
+          </div>
+        </Item>
+      ))}
+    </Menu>
+  );
+};
+
+export default ManageList;
+
+const Menu = styled.ul`
+  padding: 0 2rem 0 2rem;
+`;
+
+const Item = styled.li`
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  padding-top: 2rem;
+  font-size: ${({ theme: { fontSizes } }) => fontSizes.md}rem;
+  line-height: 24px;
+  letter-spacing: -0.5px;
+  color: ${({ theme: { colors } }) => colors.deepGray};
+
+  .svg-box {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+`;

--- a/src/components/MyPage/TempTest.jsx
+++ b/src/components/MyPage/TempTest.jsx
@@ -1,11 +1,35 @@
 import React, { useCallback } from "react";
 import styled from "styled-components";
 import SVG from "../common/SVG";
-import ENUM from "../../constants/Enum";
+import ENUM, {
+  mbti,
+  multiple,
+  weight,
+  MULTIPLE,
+  MBTI,
+  WEIGHT,
+} from "../../constants/Enum";
 import { getDateInfo } from "../../utils/handler";
 import { NoticeAlert } from "../common";
 
 const TempTest = ({ test }) => {
+  let name = "";
+  if (test) {
+    switch (test.type) {
+      case mbti:
+        name = MBTI;
+        break;
+      case multiple:
+        name = MULTIPLE;
+        break;
+      case weight:
+        name = WEIGHT;
+        break;
+
+      default:
+        break;
+    }
+  }
   const onClick = useCallback(() => {
     return NoticeAlert.open("곧 업데이트 예정이에요!");
   }, []);
@@ -13,7 +37,7 @@ const TempTest = ({ test }) => {
     <TempBox>
       <TempInfo>
         <NoticeAlert icon={ENUM.WARNING} btns={[{ name: "닫기" }]} />
-        <Type>{test.type}</Type>
+        <Type>{name !== "" && name}</Type>
         <CreateAt>{getDateInfo(test.createdAt, "temp")}</CreateAt>
       </TempInfo>
       <SvgBox>

--- a/src/components/frame/BottomBtn.js
+++ b/src/components/frame/BottomBtn.js
@@ -6,7 +6,7 @@ import { getNextPageURL } from "../../utils/handler";
 import { home, picktest } from "../../constants/urlInfo";
 import ENUM from "../../constants/Enum";
 
-const { HOME, PICKTEST, PREVIEW, MOVENEXT } = ENUM;
+const { HOME, PICKTEST, PREVIEW, MOVENEXT, LOGOUT } = ENUM;
 
 const BottomBtn = memo(({ btnArr = [], history, location, match }) => {
   const handleOnClick = async (idx, event) => {
@@ -34,6 +34,10 @@ const BottomBtn = memo(({ btnArr = [], history, location, match }) => {
         case MOVENEXT: // 다음 페이지 이동
           const next_url = getNextPageURL(match, location);
           history.push(`/${next_url}`);
+          break;
+
+        case LOGOUT: // 마이페이지(계정관리)에서 로그아웃
+          history.push("/");
           break;
 
         default:

--- a/src/constants/Enum.js
+++ b/src/constants/Enum.js
@@ -35,10 +35,26 @@ export const [
 export const [ALL] = ["전체"];
 
 // mypage
-export const [PARTTEST, MADETEST, TEMPSTORAGE] = [
+export const [
+  PARTTEST,
+  MADETEST,
+  TEMPSTORAGE,
+  CHANGEPW,
+  CHECKTERMS,
+  DELETEACCOUT,
+  MULTIPLE,
+  MBTI,
+  WEIGHT,
+] = [
   "참여 테스트",
   "만든 테스트",
   "임시저장",
+  "비밀번호 변경",
+  "약관 확인",
+  "계정 삭제",
+  "객관식 테스트",
+  "성격 테스트",
+  "유형 테스트",
 ];
 
 const ENUM = {
@@ -47,6 +63,7 @@ const ENUM = {
   PREVIEW: "preview",
   MOVENEXT: "movenext",
   SHARE: "share",
+  LOGOUT: "logout",
 
   // svg type
   ADD: "add",

--- a/src/constants/headerInfo.js
+++ b/src/constants/headerInfo.js
@@ -86,6 +86,11 @@ const headerInfo = {
     leftType: BACK,
     title: { type: TITLE, title: "마이페이지" },
   },
+
+  "mypage/manage": {
+    leftType: BACK,
+    title: { type: TITLE, title: "계정 관리" },
+  },
 };
 
 export default headerInfo;

--- a/src/hooks/useUser.js
+++ b/src/hooks/useUser.js
@@ -12,6 +12,9 @@ import {
   updatePartTests,
   updateMadeTests,
   setSelecteTab,
+  updateProfile,
+  updateNickname,
+  uploadProfile,
 } from "../redux/reducer/userReducer";
 import { INIT, LOADING, SUCCESS } from "../utils/asyncUtils";
 
@@ -23,6 +26,7 @@ const useUser = () => {
     tabTestsLast,
     isStop,
     tabTestsLoading,
+    profileUrl,
   } = useSelector((state) => state.user);
   const { data, status } = useSelector((state) => state.user.user);
   const logInLoading = useMemo(
@@ -51,6 +55,10 @@ const useUser = () => {
   const morePartTests = (payload) => dispatch(updatePartTests(payload));
   const moreMadeTests = (payload) => dispatch(updateMadeTests(payload));
 
+  const putProfile = (payload) => dispatch(updateProfile(payload));
+  const putNickname = (payload) => dispatch(updateNickname(payload));
+  const uploadImg = (payload) => dispatch(uploadProfile(payload));
+
   return {
     data,
     status,
@@ -72,6 +80,10 @@ const useUser = () => {
     getTempSaveTests,
     morePartTests,
     moreMadeTests,
+    putProfile,
+    putNickname,
+    uploadImg,
+    profileUrl,
   };
 };
 

--- a/src/redux/reducer/userReducer.js
+++ b/src/redux/reducer/userReducer.js
@@ -18,6 +18,19 @@ const initialState = {
   isStop: false,
 
   updateUserLoading: false,
+
+  // 프로필 업로드
+  profileUrl: null,
+  uploadLoading: false,
+  uploadError: false,
+
+  // 프로필 변경
+  profileLoading: false,
+  profileError: false,
+
+  // 닉네임 변경
+  nicknameLoading: false,
+  nicknameError: false,
 };
 
 const user = createSlice({
@@ -130,6 +143,44 @@ const user = createSlice({
       state.tabTestsLoading = false;
       state.tabTestsError = true;
     },
+
+    // 프로필 업로드
+    uploadProfile: (state) => {
+      state.uploadLoading = true;
+    },
+    uploadProfileSuccess: (state, { payload: { url } }) => {
+      console.log(url);
+      state.uploadLoading = false;
+      state.profileUrl = url;
+    },
+    uploadProfileError: (state) => {
+      state.uploadLoading = false;
+      state.uploadError = true;
+    },
+
+    // 프로필 변경
+    updateProfile: (state) => {
+      state.profileLoading = true;
+    },
+    updateProfileSuccess: (state) => {
+      state.profileLoading = false;
+    },
+    updateProfileError: (state) => {
+      state.profileLoading = false;
+      state.profileError = true;
+    },
+
+    // 닉네임 변경
+    updateNickname: (state) => {
+      state.nicknameLoading = true;
+    },
+    updateNicknameSuccess: (state) => {
+      state.nicknameLoading = false;
+    },
+    updateNicknameError: (state) => {
+      state.nicknameLoading = false;
+      state.nicknameError = true;
+    },
   },
 
   extraReducers: (builder) => {
@@ -164,6 +215,9 @@ export const {
   updateMadeTests,
   tempSaveTests,
   getUserInfo,
+  updateProfile,
+  updateNickname,
+  uploadProfile,
 } = user.actions;
 
 export default user;

--- a/src/redux/saga/userSaga.js
+++ b/src/redux/saga/userSaga.js
@@ -12,6 +12,9 @@ import {
   tempSaveTests,
   updatePartTests,
   updateMadeTests,
+  updateProfile,
+  updateNickname,
+  uploadProfile,
 } from "../reducer/userReducer";
 
 import {
@@ -70,6 +73,21 @@ const updateMadeTestsSaga = createPromiseSaga(
   UserAPI.madeTests
 );
 
+const updateProfileSaga = createPromiseSaga(
+  updateProfile.type,
+  UserAPI.updateProfile
+);
+
+const updateNicknameSaga = createPromiseSaga(
+  updateNickname.type,
+  UserAPI.updateNickname
+);
+
+const uploadProfileSaga = createPromiseSaga(
+  uploadProfile.type,
+  UserAPI.uploadImg
+);
+
 function* watchCheckLogin() {
   yield takeLeading(checkLogIn.type, checkLogInSaga);
 }
@@ -106,6 +124,18 @@ function* watchUpdateMadeTests() {
   yield takeLeading(updateMadeTests.type, updateMadeTestsSaga);
 }
 
+function* watchUpdateProfile() {
+  yield takeLeading(updateProfile.type, updateProfileSaga);
+}
+
+function* watchUpdateNickname() {
+  yield takeLeading(updateNickname.type, updateNicknameSaga);
+}
+
+function* watchUploadProfile() {
+  yield takeLeading(uploadProfile.type, uploadProfileSaga);
+}
+
 export default function* userSaga() {
   yield all([
     fork(watchCheckLogin),
@@ -117,5 +147,8 @@ export default function* userSaga() {
     fork(watchTempSaveTests),
     fork(watchUpdatePartTests),
     fork(watchUpdateMadeTests),
+    fork(watchUpdateProfile),
+    fork(watchUpdateNickname),
+    fork(watchUploadProfile),
   ]);
 }

--- a/src/view/mypage/AccountManage.jsx
+++ b/src/view/mypage/AccountManage.jsx
@@ -1,7 +1,210 @@
-import React from "react";
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import * as loadImage from "blueimp-load-image";
+import { getFormData } from "../../utils/asyncMakingUtils";
+import styled, { css } from "styled-components";
+import ENUM from "../../constants/Enum";
+import { Loading, SVG } from "../../components/common";
+import theme from "../../styles/theme";
+import useUser from "../../hooks/useUser";
+import AutosizeInput from "react-input-autosize";
+import Error from "../Error";
+
+const { deepGray } = theme.colors;
+const { lg } = theme.fontSizes;
 
 const AccountManage = () => {
-  return <></>;
+  const {
+    data,
+    loggedIn,
+    updateUserLoading,
+    logInLoading,
+    profileUrl,
+    putProfile,
+    putNickname,
+    uploadImg,
+  } = useUser();
+
+  const fileInput = useRef();
+  const [isHover, setHover] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+
+  const onClick = useCallback((e) => {
+    fileInput.current.click();
+  }, []);
+
+  useEffect(() => {
+    putProfile({ profileUrl: profileUrl });
+  }, [profileUrl]);
+
+  const onChange = useCallback(
+    (e) => {
+      setInputValue(e.target.value);
+    },
+    [setInputValue]
+  );
+
+  const onSubmitNick = useCallback(
+    (e) => {
+      e.preventDefault();
+      if (!inputValue || data.nickname === inputValue) return;
+      putNickname({ nickname: inputValue });
+    },
+    [inputValue]
+  );
+
+  const onKeyPress = (event) => {
+    if (event.key === "Enter") {
+      onSubmitNick();
+    }
+  };
+
+  const onUpload = async (e) => {
+    const file = e.target.files[0];
+    const fileType = file.type;
+
+    loadImage(
+      file,
+      (img) => {
+        img.toBlob(async (blob) => {
+          const rotateFile = new File([blob], file.name, { type: fileType });
+          const form = getFormData(rotateFile, "profile");
+          uploadImg(form);
+        }, fileType);
+      },
+      {
+        meta: true,
+        orientation: true,
+        canvas: true,
+        maxWidth: 500,
+      }
+    );
+  };
+
+  if (!loggedIn) return <Error code={403} />;
+  return logInLoading ? (
+    <Loading loading={updateUserLoading} />
+  ) : (
+    <Container>
+      <ProfileBox>
+        <div>
+          <Profile isHover={isHover}>
+            {data.profileImg ? (
+              <img
+                src={data.profileImg}
+                alt={"이미지"}
+                style={imgStyle}
+                onClick={onClick}
+              />
+            ) : (
+              profileUrl && (
+                <img
+                  src={profileUrl}
+                  alt={"이미지"}
+                  style={imgStyle}
+                  onClick={onClick}
+                />
+              )
+            )}
+          </Profile>
+          <SvgBox>
+            <SVG
+              type={ENUM.CONFIRM}
+              style={{ width: "24", height: "24" }}
+              onClick={onClick}
+              onKeyPress={onKeyPress}
+            />
+          </SvgBox>
+        </div>
+        <Form onSubmit={onSubmitNick}>
+          <AutosizeInput
+            name="form-field-name"
+            placeholder={data.nickname}
+            value={inputValue}
+            onChange={onChange}
+            inputStyle={inputStyle}
+          />
+          <Button type="submit">
+            <SVG
+              type={ENUM.CONFIRM}
+              style={{ width: "24", height: "24" }}
+              onClick={() => {
+                return;
+              }}
+            />
+          </Button>
+        </Form>
+      </ProfileBox>
+
+      <Menu></Menu>
+
+      <input
+        type="file"
+        accept=".jpg, .jpeg, .png;capture=camera"
+        ref={fileInput}
+        onChange={onUpload}
+        style={{ width: 0, display: "none" }}
+      />
+    </Container>
+  );
 };
 
 export default AccountManage;
+
+const Container = styled.div``;
+
+const ProfileBox = styled.div`
+  position: relative;
+  margin-top: 2.3rem;
+  border-bottom: 3px solid ${({ theme: { colors } }) => colors.ghostGray};
+  padding-bottom: ${({ theme: { fontSizes } }) => fontSizes.xl}rem;
+`;
+
+const Profile = styled.div`
+  position: relative;
+  margin: 0px auto;
+  width: 7.6rem;
+  height: 7.6rem;
+  img:hover {
+    cursor: pointer;
+    opacity: 0.5;
+  }
+`;
+const imgStyle = {
+  width: "100%",
+  height: "100%",
+  borderRadius: "50%",
+  margin: "0px auto",
+};
+
+const inputStyle = {
+  border: "none",
+  outline: "none",
+  fontWeight: "bold",
+  fontSize: `${lg}rem`,
+  lineHeight: "26px",
+  textAlign: "center",
+  color: deepGray,
+};
+
+const SvgBox = styled.div`
+  position: absolute;
+  left: 53%;
+  top: 39%;
+`;
+
+const Form = styled.form`
+  padding-top: 20px;
+  text-align: center;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Menu = styled.div``;

--- a/src/view/mypage/AccountManage.jsx
+++ b/src/view/mypage/AccountManage.jsx
@@ -1,13 +1,15 @@
 import React, { useState, useRef, useCallback, useEffect } from "react";
 import * as loadImage from "blueimp-load-image";
 import { getFormData } from "../../utils/asyncMakingUtils";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import ENUM from "../../constants/Enum";
 import { Loading, SVG } from "../../components/common";
 import theme from "../../styles/theme";
 import useUser from "../../hooks/useUser";
 import AutosizeInput from "react-input-autosize";
 import Error from "../Error";
+import BottomBtn, { PageContainer } from "../../components/frame/BottomBtn";
+import ManageList from "../../components/MyPage/ManageList";
 
 const { deepGray } = theme.colors;
 const { lg } = theme.fontSizes;
@@ -22,6 +24,7 @@ const AccountManage = () => {
     putProfile,
     putNickname,
     uploadImg,
+    logOut,
   } = useUser();
 
   const fileInput = useRef();
@@ -33,7 +36,7 @@ const AccountManage = () => {
   }, []);
 
   useEffect(() => {
-    putProfile({ profileUrl: profileUrl });
+    profileUrl && putProfile({ profileUrl: profileUrl });
   }, [profileUrl]);
 
   const onChange = useCallback(
@@ -84,7 +87,7 @@ const AccountManage = () => {
   return logInLoading ? (
     <Loading loading={updateUserLoading} />
   ) : (
-    <Container>
+    <PageContainer>
       <ProfileBox>
         <div>
           <Profile isHover={isHover}>
@@ -135,7 +138,7 @@ const AccountManage = () => {
         </Form>
       </ProfileBox>
 
-      <Menu></Menu>
+      <ManageList />
 
       <input
         type="file"
@@ -144,13 +147,14 @@ const AccountManage = () => {
         onChange={onUpload}
         style={{ width: 0, display: "none" }}
       />
-    </Container>
+      <BottomBtn
+        btnArr={[{ name: "로그아웃", type: ENUM.LOGOUT, customClick: logOut }]}
+      />
+    </PageContainer>
   );
 };
 
 export default AccountManage;
-
-const Container = styled.div``;
 
 const ProfileBox = styled.div`
   position: relative;
@@ -207,4 +211,14 @@ const Button = styled.button`
   align-items: center;
 `;
 
-const Menu = styled.div``;
+const Menu = styled.ul`
+  padding: 0 2rem 0 2rem;
+`;
+
+const Item = styled.li`
+  font-weight: bold;
+  font-size: ${({ theme: { fontSizes } }) => fontSizes.md}rem;
+  line-height: 24px;
+  letter-spacing: -0.5px;
+  color: ${({ theme: { colors } }) => colors.deepGray};
+`;

--- a/src/view/mypage/MypageMain.jsx
+++ b/src/view/mypage/MypageMain.jsx
@@ -7,10 +7,11 @@ import Tab from "../../components/MyPage/Tab";
 import useUser from "../../hooks/useUser";
 import Error from "../Error";
 import TabTests from "../../components/MyPage/TabTests";
-// import usePage from "../../hooks/usePage";
+import usePage from "../../hooks/usePage";
 // import { LOADING, SUCCESS } from "../../utils/asyncUtils";
 
 const MypageMain = memo((props) => {
+  const { goPage } = usePage();
   const {
     logInLoading,
     loggedIn,
@@ -39,6 +40,10 @@ const MypageMain = memo((props) => {
     return NoticeAlert.open("곧 업데이트 예정이에요!");
   }, []);
 
+  const onClickAccount = () => {
+    return goPage("/mypage/manage");
+  };
+
   if (!loggedIn) return <Error code={403} />;
   return updateUserLoading ? (
     <Loading loading={updateUserLoading} />
@@ -55,7 +60,7 @@ const MypageMain = memo((props) => {
                 <EmptyImg />
               )}
             </InfoAva>
-            <Partition onClick={onClick}>{data.nickname}</Partition>
+            <Partition onClick={onClickAccount}>{data.nickname}</Partition>
           </div>
           <div className="space-right">
             <SVG
@@ -64,7 +69,7 @@ const MypageMain = memo((props) => {
                 width: "24",
                 height: "24",
               }}
-              onClick={onClick}
+              onClick={onClickAccount}
             />
           </div>
         </InfoUser>


### PR DESCRIPTION
✅ 마이페이지
 - [ ] 북마크 불러오기 (북마크 삭제도 필요, 추후 피드에서 북마크 넣으면 해야함)
 - [ ] 내가 쓴 댓글 API 완료되면 가능
 - [x] 임시저장 ( type 이름 바꾸기, 임시저장 이동) -> 임시저장 이동 힘들듯 ...^^

✅ 계정관리
 - [x] 프로필 변경 (코드 개선 필요, 삭제도 필요) -> 프로필 삭제는 API와 디자인 필요함
 - [x] 닉네임 변경 ->
  1. 변경 잘됨
  2. 중복확인 필요없음
  3. 테스트와 댓글에 반영필요 (백엔드가)
  4. 닉네임 input은 `react-input-autosize`라이브러리 이용 (동적으로 input의 길이를 움직임)
  
⬇ 계정관리 메뉴들은 API 및 디자인이 있어야 개발 가능
- [ ] 비밀번호 변경 ->
  1. 이메일로 로그인시에만 가능
  2. 소셜로그인과 이메일 로그인 구분 필요 ( 소셜로그인이면 비밀번호 변경 안띄우는게 낫겟죠)
- [ ] 약관 확인(디자인 및 정책 필요)
- [ ] 계정 삭제 필요